### PR TITLE
perf: fix mobile Lighthouse warnings for unused preconnect and CLS

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,10 +70,6 @@
 	<link rel="icon" type="image/svg+xml" href="/add-circle.svg" />
 	<link rel="preload" href="/src/assets/Virgil.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
 	<link rel="preload" href="/src/assets/photo.webp" as="image" type="image/webp" fetchpriority="high" />
-	<link rel="dns-prefetch" href="https://assets.calendly.com" />
-	<link rel="preconnect" href="https://assets.calendly.com" crossorigin />
-	<link rel="dns-prefetch" href="https://calendly.com" />
-	<link rel="preconnect" href="https://calendly.com" crossorigin />
 	<title>
 		Chetan Bohra — Senior Backend Engineer | NestJS, Node.js,
 		PostgreSQL, AWS | New Delhi

--- a/src/components/views/Introduction.tsx
+++ b/src/components/views/Introduction.tsx
@@ -37,7 +37,7 @@ const Introduction = memo(() => {
 			<div className='flex flex-col justify-center'>
 				<Label className='font-virgil text-center md:text-start text-4xl pt-4'>
 					<span className='italic'>Hello,</span> I am{' '}
-					<span className='text-green-500 hover:text-lime-300'>
+					<span className='inline-block min-h-[1.2em] text-green-500 hover:text-lime-300'>
 						<TypeAnimation
 							sequence={TYPE_ANIMATION_SEQUENCE}
 							repeat={Infinity}

--- a/src/components/views/ScheduleMeet.tsx
+++ b/src/components/views/ScheduleMeet.tsx
@@ -11,6 +11,21 @@ const ScheduleMeet = memo(() => {
 		const observer = new IntersectionObserver(
 			(entries) => {
 				if (entries[0].isIntersecting) {
+					// Inject preconnect hints right before the widget loads
+					const hints: HTMLLinkElement[] = [];
+					for (const [rel, href, crossorigin] of [
+						['dns-prefetch', 'https://assets.calendly.com', false],
+						['preconnect', 'https://assets.calendly.com', true],
+						['dns-prefetch', 'https://calendly.com', false],
+						['preconnect', 'https://calendly.com', true],
+					] as [string, string, boolean][]) {
+						const link = document.createElement('link');
+						link.rel = rel;
+						link.href = href;
+						if (crossorigin) link.crossOrigin = 'anonymous';
+						document.head.appendChild(link);
+						hints.push(link);
+					}
 					setShouldLoad(true);
 					observer.disconnect();
 				}


### PR DESCRIPTION
- Remove hardcoded Calendly dns-prefetch/preconnect from index.html; inject them dynamically in ScheduleMeet only when the widget is about to enter the viewport, eliminating the "unused preconnect" warning
- Add inline-block + min-h-[1.2em] to TypeAnimation wrapper span so the surrounding layout has a reserved height as text animates, reducing CLS caused by the typing effect changing text length

https://claude.ai/code/session_01G2tQVrrF8einq5QiEH3xwU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Calendly resource preloading now occurs dynamically when the scheduling component is accessed rather than during initial page load.

* **Style**
  * Enhanced animated text element display with updated layout properties for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->