### PR TITLE
perf: fix CLS regression and eliminate render-blocking CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,8 @@
 	<link rel="icon" type="image/svg+xml" href="/add-circle.svg" />
 	<link rel="preload" href="/src/assets/Virgil.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
 	<link rel="preload" href="/src/assets/photo.webp" as="image" type="image/webp" fetchpriority="high" />
+	<!-- Critical CSS: prevents FOUC while the full stylesheet loads asynchronously -->
+	<style>:root{--background:0 0% 100%;--foreground:240 10% 3.9%}*,::before,::after{box-sizing:border-box;border-width:0;border-style:solid}html{line-height:1.5;-webkit-text-size-adjust:100%}body{margin:0;background-color:hsl(0 0% 100%);color:hsl(240 10% 3.9%)}</style>
 	<title>
 		Chetan Bohra — Senior Backend Engineer | NestJS, Node.js,
 		PostgreSQL, AWS | New Delhi

--- a/src/components/views/Introduction.tsx
+++ b/src/components/views/Introduction.tsx
@@ -36,8 +36,10 @@ const Introduction = memo(() => {
 
 			<div className='flex flex-col justify-center'>
 				<Label className='font-virgil text-center md:text-start text-4xl pt-4'>
-					<span className='italic'>Hello,</span> I am{' '}
-					<span className='inline-block min-h-[1.2em] text-green-500 hover:text-lime-300'>
+					<span className='block'>
+						<span className='italic'>Hello,</span> I am
+					</span>
+					<span className='block h-[5rem] xxs:h-[2.5rem] text-green-500 hover:text-lime-300'>
 						<TypeAnimation
 							sequence={TYPE_ANIMATION_SEQUENCE}
 							repeat={Infinity}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,28 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
+// Converts the emitted <link rel="stylesheet"> to a non-render-blocking preload.
+// A minimal inline <style> in index.html covers above-fold critical CSS so
+// there is no flash of unstyled content while the full stylesheet loads async.
+function deferStylesheets(): Plugin {
+	return {
+		name: 'defer-stylesheets',
+		apply: 'build',
+		transformIndexHtml(html: string) {
+			return html.replace(
+				/<link rel="stylesheet" crossorigin href="([^"]+\.css)">/g,
+				(_, href) =>
+					`<link rel="preload" as="style" crossorigin href="${href}" onload="this.rel='stylesheet'">` +
+					`<noscript><link rel="stylesheet" crossorigin href="${href}"></noscript>`,
+			);
+		},
+	};
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [react()],
+	plugins: [react(), deferStylesheets()],
 	resolve: {
 		alias: {
 			'@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
CLS fix: restructure TypeAnimation onto its own fixed-height block element (h-[5rem] on tiny phones, xxs:h-[2.5rem] on 480px+) so varying text lengths can no longer shift elements below the heading. Previously the animation was inline with "Hello, I am", causing multi-line wraps to change the Label's height and double CLS from 0.031 to 0.071.

Render-blocking CSS: add deferStylesheets Vite plugin that converts the emitted <link rel="stylesheet"> to a non-blocking preload + noscript fallback. Inline minimal critical CSS (~200 bytes) in index.html to prevent FOUC while the full 4.9 KiB stylesheet loads asynchronously, targeting the 150ms critical-path saving flagged by PageSpeed.

https://claude.ai/code/session_01G2tQVrrF8einq5QiEH3xwU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flash of unstyled content on page load.

* **Style**
  * Improved stylesheet delivery performance with deferred loading and optimized introduction section layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->